### PR TITLE
Fix geojson cache test

### DIFF
--- a/mapentity/decorators.py
+++ b/mapentity/decorators.py
@@ -69,10 +69,10 @@ def view_cache_latest():
             cache_latest = cache_last_modified(lambda x: view_model.latest_updated())
             cbv_cache_latest = method_decorator(cache_latest)
 
-            # The first decorator allows browser's cache revalidation.
-            # The second one forces browser's cache revalidation.
-            @cbv_cache_latest
+            # The first decorator forces browser's cache revalidation.
+            # The second one allows browser's cache revalidation.
             @method_decorator(never_cache)
+            @cbv_cache_latest
             def decorated(self, request, *args, **kwargs):
                 return view_func(self, request, *args, **kwargs)
 

--- a/mapentity/tests/test_functional.py
+++ b/mapentity/tests/test_functional.py
@@ -271,12 +271,14 @@ class MapEntityLiveTest(LiveServerTestCase):
         self.assertEqual(expires, lastmodified)
 
         # Try again, check that nothing changed
+        time.sleep(1.1)
+        self.assertEqual(latest, self.model.latest_updated())
         response = self.session.get(geojson_layer_url)
         self.assertEqual(lastmodified, response.headers.get('Last-Modified'))
         self.assertEqual(md5sum, md5.new(response.content).digest())
 
         # Create a new object
-        time.sleep(1)  # wait some time, last-modified has precision in seconds
+        time.sleep(1.1)  # wait some time, last-modified has precision in seconds
         self.modelfactory.create()
         latest_updated.return_value = datetime.utcnow().replace(tzinfo=utc)
 


### PR DESCRIPTION
@gutard you were right, adding a sleep time made the tests fail.

I noticied that `@never_cache` was setting `Last-Modified` before `@last_modified`, preventing the correct value to be set.
