### PR TITLE
Fix geojson caching

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,10 @@ CHANGELOG
 1.10.4 (unreleased)
 ===================
 
+**Bug fixes**
+
+- Fix geojson caching that returns sometime "None" instead of valid json
+
 
 1.10.3 (2014-12-18)
 ===================


### PR DESCRIPTION
The content cache key may be removed by the cache manager but the date key still existst. In that case the cache decorator returns "None".