### PR TITLE
Add geojson support to REST API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,10 +2,12 @@
 CHANGELOG
 =========
 
-1.10.6.dev (unreleased)
+1.11.0.dev (unreleased)
 ===================
 
--
+**New features**
+
+- Add geojson support to REST API
 
 
 1.10.5 (2015-01-21)

--- a/mapentity/registry.py
+++ b/mapentity/registry.py
@@ -17,6 +17,7 @@ from rest_framework import serializers as rest_serializers
 from mapentity import models as mapentity_models
 from mapentity.middleware import get_internal_user
 from mapentity import logger
+from mapentity import app_settings
 
 from paperclip import models as paperclip_models
 
@@ -125,6 +126,7 @@ class MapEntityOptions(object):
         class Serializer(rest_serializers.ModelSerializer):
             class Meta:
                 model = _model
+                geo_field = app_settings['GEOM_FIELD_NAME']
 
         return Serializer
 

--- a/mapentity/renderers.py
+++ b/mapentity/renderers.py
@@ -1,0 +1,5 @@
+from rest_framework.renderers import JSONRenderer
+
+
+class GeoJSONRenderer(JSONRenderer):
+    format = 'geojson'

--- a/mapentity/settings.py
+++ b/mapentity/settings.py
@@ -60,7 +60,12 @@ REST_FRAMEWORK_DEFAULT_CONFIG = {
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
         'mapentity.models.MapEntityRestPermissions'
-    ]
+    ],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+        'mapentity.renderers.GeoJSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ],
 }
 REST_FRAMEWORK_DEFAULT_CONFIG.update(getattr(settings, 'REST_FRAMEWORK', {}))
 setattr(settings, 'REST_FRAMEWORK', REST_FRAMEWORK_DEFAULT_CONFIG)

--- a/mapentity/views/api.py
+++ b/mapentity/views/api.py
@@ -4,6 +4,7 @@ from django.views.generic.list import ListView
 
 from djgeojson.views import GeoJSONLayerView
 from rest_framework import viewsets
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from mapentity import models as mapentity_models
 from ..settings import API_SRID
@@ -70,4 +71,11 @@ class MapEntityJsonList(JSONResponseMixin, BaseListView, ListView):
 
 
 class MapEntityViewSet(viewsets.ModelViewSet):
-    pass
+    def get_serializer_class(self):
+        serializer = super(MapEntityViewSet, self).get_serializer_class()
+        renderer, media_type = self.perform_content_negotiation(self.request)
+        if getattr(renderer, 'format') == 'geojson':
+            class Serializer(serializer, GeoFeatureModelSerializer):
+                pass
+            return Serializer
+        return serializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-tinymce==1.5.1
 django-appypod>=0.0.2
 django-leaflet>=0.14
 django-geojson==2.6.0
+djangorestframework-gis==0.7


### PR DESCRIPTION
Now, `/api/<modelname>s/.geojson` returns GeoJSON formatted data