### PR TITLE
Use translated fieldnames shapefile

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,9 @@ CHANGELOG
 2.5.3.dev0
 ==================
 
--
+**Breaking changes**
+
+- Use translated verbose_name fields instead of column/property names in shapefiles export
 
 2.5.2 (2015-07-29)
 ==================

--- a/mapentity/serializers/shapefile.py
+++ b/mapentity/serializers/shapefile.py
@@ -28,6 +28,8 @@ try:
 except ImportError:
     from StringIO import StringIO  # noqa
 
+os.environ["SHAPE_ENCODING"] = "UTF-8"
+
 
 class ZipShapeSerializer(Serializer):
     def __init__(self, *args, **kwargs):
@@ -140,7 +142,7 @@ def shape_write(iterable, model, columns, get_geom, geom_type, srid, srid_out=No
 
         reponse = unicode(c)
         reponse = unicodedata.normalize('NFD', reponse)
-        reponse = smart_str(reponse.encode('ascii', 'ignore')).replace(' ', '_')
+        reponse = smart_str(reponse.encode('ascii', 'ignore')).replace(' ', '_').lower()
 
         headers.append(reponse)
         columns_headers[field] = reponse
@@ -165,7 +167,9 @@ def shape_write(iterable, model, columns, get_geom, geom_type, srid, srid_out=No
         for fieldname in columns:
             # They are all String (see create_shape_format_layer)
             value = field_as_string(item, fieldname, ascii=True)
-            feat.SetField(column_map.get(columns_headers.get(fieldname)), value[:254])
+
+            feat.SetField(column_map.get(columns_headers.get(fieldname)),
+                          value[:254])
 
         geom = get_geom(item)
         if geom:

--- a/mapentity/tests/test_serializers.py
+++ b/mapentity/tests/test_serializers.py
@@ -1,6 +1,6 @@
 import os
 from StringIO import StringIO
-from django.utils.translation import ugettext as _
+
 from django.test import TestCase
 from django.conf import settings
 from django.contrib.gis.db.models import GeometryField
@@ -54,8 +54,7 @@ class ShapefileSerializer(TestCase):
     def test_layer_has_right_projection(self):
         for layer in self.getShapefileLayers():
             self.assertEquals(layer.srs.name, 'RGF93_Lambert_93')
-            raise Exception(u"%s" % layer.fields)
-            self.assertItemsEqual(layer.fields, [_('id'), _('name'), _('number'), _('size'), _('boolean')])
+            self.assertItemsEqual(layer.fields, ['ID', 'name', 'number', 'size', 'boolean'])
 
     def test_geometries_come_from_records(self):
         layer_point, layer_multipoint, layer_linestring = self.getShapefileLayers()

--- a/mapentity/tests/test_serializers.py
+++ b/mapentity/tests/test_serializers.py
@@ -54,7 +54,7 @@ class ShapefileSerializer(TestCase):
     def test_layer_has_right_projection(self):
         for layer in self.getShapefileLayers():
             self.assertEquals(layer.srs.name, 'RGF93_Lambert_93')
-            self.assertItemsEqual(layer.fields, ['ID', 'name', 'number', 'size', 'boolean'])
+            self.assertItemsEqual(layer.fields, ['id', 'name', 'number', 'size', 'boolean'])
 
     def test_geometries_come_from_records(self):
         layer_point, layer_multipoint, layer_linestring = self.getShapefileLayers()

--- a/mapentity/tests/test_serializers.py
+++ b/mapentity/tests/test_serializers.py
@@ -1,6 +1,6 @@
 import os
 from StringIO import StringIO
-
+from django.utils.translation import ugettext as _
 from django.test import TestCase
 from django.conf import settings
 from django.contrib.gis.db.models import GeometryField
@@ -54,7 +54,7 @@ class ShapefileSerializer(TestCase):
     def test_layer_has_right_projection(self):
         for layer in self.getShapefileLayers():
             self.assertEquals(layer.srs.name, 'RGF93_Lambert_93')
-            self.assertItemsEqual(layer.fields, ['id', 'name', 'number', 'size', 'boolean'])
+            self.assertItemsEqual(layer.fields, [_('id'), _('name'), _('number'), _('size'), _('boolean')])
 
     def test_geometries_come_from_records(self):
         layer_point, layer_multipoint, layer_linestring = self.getShapefileLayers()

--- a/mapentity/tests/test_serializers.py
+++ b/mapentity/tests/test_serializers.py
@@ -54,6 +54,7 @@ class ShapefileSerializer(TestCase):
     def test_layer_has_right_projection(self):
         for layer in self.getShapefileLayers():
             self.assertEquals(layer.srs.name, 'RGF93_Lambert_93')
+            raise Exception(u"%s" % layer.fields)
             self.assertItemsEqual(layer.fields, [_('id'), _('name'), _('number'), _('size'), _('boolean')])
 
     def test_geometries_come_from_records(self):


### PR DESCRIPTION
verbose name field instead of column/property name for shapefile export