### PR TITLE
Fix js sorting elements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix /logentry/list/ crash
+- Fix sort list
 
 
 5.0.0 (2018-05-07)

--- a/mapentity/static/mapentity/mapentity.context.js
+++ b/mapentity/static/mapentity/mapentity.context.js
@@ -26,7 +26,7 @@ MapEntity.Context = new function() {
         // Sort columns
         if (datatable) {
             context['sortcolumns'] = last_sort;
-            context['sortcolumns'][$('body').attr('data-appname')] = datatable.fnSettings().aaSorting;
+            context['sortcolumns'][$('body').attr('data-modelname')] = datatable.fnSettings().aaSorting;
         }
 
         // Extra-info, not restored so far but can be useful for screenshoting
@@ -118,9 +118,9 @@ MapEntity.Context = new function() {
         }
 
         if (datatable && context.sortcolumns) {
-            if ($('body').attr('data-appname') in context.sortcolumns) {
-                datatable.fnSort(context.sortcolumns[$('body').attr('data-appname')]);
-                }
+            if ($('body').attr('data-modelname') in context.sortcolumns) {
+                datatable.fnSort(context.sortcolumns[$('body').attr('data-modelname')]);
+            }
             last_sort = context['sortcolumns'];
         }
 

--- a/mapentity/static/mapentity/mapentity.context.js
+++ b/mapentity/static/mapentity/mapentity.context.js
@@ -1,6 +1,6 @@
 MapEntity.Context = new function() {
     var self = this;
-
+    var last_sort = {};
     self.getFullContext = function(map, kwargs) {
         var context = {},
             filter = kwargs && kwargs.filter,
@@ -25,7 +25,8 @@ MapEntity.Context = new function() {
 
         // Sort columns
         if (datatable) {
-            context['sortcolumns'] = datatable.fnSettings().aaSorting;
+            context['sortcolumns'] = last_sort;
+            context['sortcolumns'][$('body').attr('data-appname')] = datatable.fnSettings().aaSorting;
         }
 
         // Extra-info, not restored so far but can be useful for screenshoting
@@ -117,7 +118,10 @@ MapEntity.Context = new function() {
         }
 
         if (datatable && context.sortcolumns) {
-            datatable.fnSort(context.sortcolumns);
+            if ($('body').attr('data-appname') in context.sortcolumns) {
+                datatable.fnSort(context.sortcolumns[$('body').attr('data-appname')]);
+                }
+            last_sort = context['sortcolumns'];
         }
 
         // This map view change will refresh the list


### PR DESCRIPTION
A fix for the problem in mapentity. We keep the information between the pages and keep the type to sort only when it was already specified.