### PR TITLE
Fix easy-thumbnail dependencies and lint (flake8 5.0.0)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,7 @@ Create a *virtualenv*, and activate it::
 
 Then install the Python packages::
 
-    $ pip install django-mapentity
+    $ pip install mapentity
 
 Since you will PostgreSQL, also install its python library::
 

--- a/mapentity/forms.py
+++ b/mapentity/forms.py
@@ -247,8 +247,9 @@ class MapEntityForm(TranslatedModelForm):
             <ul class="nav nav-pills offset-md-3">
             {{% for lang in TRANSLATED_LANGUAGES %}}
                 <li class="nav-item">
-                    <a class="nav-link{{% if lang.0 == '{lang_code}'""" """ %}} active{{% endif %}}" href="#{field}_{{{{ lang.0 }}}}"
-                        data-toggle="tab">{{{{ lang.0 }}}}
+                    <a class="nav-link{{% if lang.0 == '{lang_code}'""" """ %}}
+                       active{{% endif %}}" href="#{field}_{{{{ lang.0 }}}}"
+                       data-toggle="tab">{{{{ lang.0 }}}}
                     </a>
                 </li>
             {{% endfor %}}

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'djangorestframework',
         'djangorestframework-gis',
         'djangorestframework-datatables',
-        'easy-thumbnails',
+        'easy-thumbnails[svg]',
         'fiona',
         'gpxpy',
         'netifaces',

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -401,14 +401,18 @@ class DetailViewTest(BaseTest):
 
         app_settings['MAPENTITY_WEASYPRINT'] = tmp
 
-        self.assertContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" href="/document/dummymodel-{}.odt">\
-<img src="/static/paperclip/fileicons/odt.png"/> ODT</a>'.format(self.object.pk))
-        self.assertContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" \
-href="/convert/?url=/document/dummymodel-{}.odt&to=doc">\
-<img src="/static/paperclip/fileicons/doc.png"/> DOC</a>'.format(self.object.pk))
-        self.assertContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" \
-href="/convert/?url=/document/dummymodel-{}.odt">\
-<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
+        self.assertContains(response,
+                            '<a class="btn btn-light btn-sm" rel="noopener noreferrer"'
+                            ' target="_blank" href="/document/dummymodel-{}.odt">'
+                            '<img src="/static/paperclip/fileicons/odt.png"/> ODT</a>'.format(self.object.pk))
+        self.assertContains(response,
+                            '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank"'
+                            ' href="/convert/?url=/document/dummymodel-{}.odt&to=doc">'
+                            '<img src="/static/paperclip/fileicons/doc.png"/> DOC</a>'.format(self.object.pk))
+        self.assertContains(response,
+                            '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank"'
+                            ' href="/convert/?url=/document/dummymodel-{}.odt">'
+                            '<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
 
     def test_export_buttons_weasyprint(self):
         self.login()
@@ -421,16 +425,23 @@ href="/convert/?url=/document/dummymodel-{}.odt">\
         app_settings['MAPENTITY_WEASYPRINT'] = tmp
 
         if app_settings['MAPENTITY_WEASYPRINT']:
-            self.assertContains(response, '<a class="btn btn-light btn-sm" target="_blank" href="/document/dummymodel-{}.pdf">\
-<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
+            self.assertContains(response,
+                                '<a class="btn btn-light btn-sm" target="_blank"'
+                                ' href="/document/dummymodel-{}.pdf">'
+                                '<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
         else:
-            self.assertContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" href="/document/dummymodel-{}.odt">\
-<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
-        self.assertNotContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" \
-href="/convert/?url=/document/dummymodel-{}.odt&to=doc">\
-<img src="/static/paperclip/fileicons/doc.png"/> DOC</a>'.format(self.object.pk))
-        self.assertNotContains(response, '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank" \
-href="/document/dummymodel-{}.odt"><img src="/static/paperclip/fileicons/odt.png"/> ODT</a>'.format(self.object.pk))
+            self.assertContains(response,
+                                '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank"'
+                                ' href="/document/dummymodel-{}.odt">'
+                                '<img src="/static/paperclip/fileicons/pdf.png"/> PDF</a>'.format(self.object.pk))
+        self.assertNotContains(response,
+                               '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank"'
+                               ' href="/convert/?url=/document/dummymodel-{}.odt&to=doc">'
+                               '<img src="/static/paperclip/fileicons/doc.png"/> DOC</a>'.format(self.object.pk))
+        self.assertNotContains(response,
+                               '<a class="btn btn-light btn-sm" rel="noopener noreferrer" target="_blank"'
+                               ' href="/document/dummymodel-{}.odt">'
+                               '<img src="/static/paperclip/fileicons/odt.png"/> ODT</a>'.format(self.object.pk))
 
     def test_detail_fragment(self):
         self.login()


### PR DESCRIPTION
- Fix lint due to pythoncodestyle new version
- Fix dependencies error due to easy-thumbnail new version https://pypi.org/project/easy-thumbnails/2.8.2/
  > Version 2.8.0 adds support for thumbnailing SVG images when installed with the [svg] extra.