### PR TITLE
Disable scroll propagation on layers list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ CHANGELOG
 **Bug fix**
 
 - Do not try to generate filters in list views for `GenericRelation` fields and `File` fields
+- Disable scroll propagation on layers list to avoid zoom changes on map
+
 
 
 8.3.0 (2022-12-12)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ CHANGELOG
 **Bug fix**
 
 - Do not try to generate filters in list views for `GenericRelation` fields and `File` fields
-- Disable scroll propagation on layers list to avoid zoom changes on map
+- Disable scroll propagation on layers list to avoid zoom changes on map (fix https://github.com/GeotrekCE/Geotrek-admin/issues/2687)
 
 
 

--- a/mapentity/static/mapentity/mapentity.map.js
+++ b/mapentity/static/mapentity/mapentity.map.js
@@ -111,6 +111,9 @@ $(window).on('entity:map', function (e, data) {
     var layerscontrol = L.control.groupedLayers(baseLayers, {'': overlaysLayers});
     map.layerscontrol = layerscontrol.addTo(map);
 
+    // Disable scroll on overlay form to avoid map zoom change when scroll on layers list
+    L.DomEvent.disableScrollPropagation(layerscontrol._container);
+
     if (readonly) {
         // Set map readonly
         map.dragging.disable();
@@ -145,9 +148,6 @@ $(window).on('entity:map', function (e, data) {
         $('#id_bbox').val(L.Util.getWKT(rect));
     });
 
-    // Disable scroll on overlay form to avoid map zoom change when scroll on layers list
-    layersControlDiv = document.getElementsByClassName('leaflet-control-layers-list')[0];
-    L.DomEvent.disableScrollPropagation(layersControlDiv);
 });
 
 

--- a/mapentity/static/mapentity/mapentity.map.js
+++ b/mapentity/static/mapentity/mapentity.map.js
@@ -144,6 +144,10 @@ $(window).on('entity:map', function (e, data) {
         //this.options.filter.bboxfield.val(L.Util.getWKT(rect));
         $('#id_bbox').val(L.Util.getWKT(rect));
     });
+
+    // Disable scroll on overlay form to avoid map zoom change when scroll on layers list
+    layersControlDiv = document.getElementsByClassName('leaflet-control-layers-list')[0];
+    L.DomEvent.disableScrollPropagation(layersControlDiv);
 });
 
 


### PR DESCRIPTION
This PR fixes issue notified in https://github.com/GeotrekCE/Geotrek-admin/issues/2687

This could be fixed in [Leaflet.groupedlayercontrol](https://github.com/ismyrnow/leaflet-groupedlayercontrol) plugin, but [this PR](https://github.com/ismyrnow/leaflet-groupedlayercontrol/pull/64) whic seems to fix it is not merged yet.