### PR TITLE
✨ [FEAT] Add native browser spell checking for TineMCE managed textAreas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,18 @@ CHANGELOG
 8.5.6+dev  (XXXX-XX-XX)
 ----------------------------
 
-* Support django 4.2 and python 3.11
-* Drop django 3.1 support
-* Ease quickstart for developers
+**Feature**
+
+- Modify TinyMCE configuration to add browser spelling check for textAreas (related to https://github.com/GeotrekCE/Geotrek-admin/issues/1189)
+
+**Maintenance**
+
+- Support django 4.2 and python 3.11
+- Drop django 3.1 support
+
+**Documentation**
+
+- Ease quickstart for developers
 
 **Minor fixes**
 

--- a/mapentity/settings.py
+++ b/mapentity/settings.py
@@ -69,6 +69,8 @@ TINYMCE_DEFAULT_CONFIG = {
     'forced_root_block': False,
     'width': '95%',
     'resize': "both",
+    'browser_spellcheck': True,
+    'contextmenu': False,
     'valid_elements': ('@[id|class|style|title|dir<ltr?rtl|lang|xml::lang],'
                        'a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class],'
                        'img[longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align],'


### PR DESCRIPTION
This commit fix https://github.com/GeotrekCE/Geotrek-admin/issues/1189 

It uses this configuration from the TinyMCE documentation : https://www.tiny.cloud/docs/general-configuration-guide/spell-checking/#browser-basedspellchecking