### PR TITLE
✨ [FEAT] Add in TinyMCE Areas possibility for the user to upload a local file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,18 @@ CHANGELOG
 8.5.6+dev  (XXXX-XX-XX)
 ----------------------------
 
-* Support django 4.2 and python 3.11
-* Drop django 3.1 support
-* Ease quickstart for developers
+**Feature**
+
+- Allow the user to upload file from TinyMCE editor to insert local images directly into the text area
+
+**Maintenance**
+
+- Support django 4.2 and python 3.11
+- Drop django 3.1 support
+
+**Documentation**
+
+- Ease quickstart for developers
 
 
 8.5.6      (2023-09-04)

--- a/mapentity/settings.py
+++ b/mapentity/settings.py
@@ -74,7 +74,13 @@ TINYMCE_DEFAULT_CONFIG = {
                        'img[longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align],'
                        'p,em/i,strong/b,div[align],br,ul,li,ol,span[style],'
                        'iframe[src|frameborder=0|alt|title|width|height|align|name]'),
-    'setup': 'tinyMceInit'
+    'setup': 'tinyMceInit',
+    'image_title': True,
+    'image_caption': True,
+    'automatic_uploads': True,
+    'convert_urls': False,
+    'file_picker_types': 'image media',
+    'images_upload_url': '/tinymce/upload/',
 }
 TINYMCE_DEFAULT_CONFIG.update(getattr(settings, 'TINYMCE_DEFAULT_CONFIG', {}))
 setattr(settings, 'TINYMCE_DEFAULT_CONFIG', TINYMCE_DEFAULT_CONFIG)

--- a/mapentity/urls.py
+++ b/mapentity/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, re_path, include
 
 from .registry import registry
 from .settings import app_settings
-from .views import (map_screenshot, history_delete,
+from .views import (map_screenshot, history_delete, tinymce_upload,
                     ServeAttachment, JSSettings, Convert)
 
 if app_settings['ACTION_HISTORY_ENABLED']:
@@ -23,6 +23,7 @@ urlpatterns = [
     path('convert/', Convert.as_view(), name='convert'),
     path('history/delete/', history_delete, name='history_delete'),
     path('api/auth/', include('rest_framework.urls')),
+    path('tinymce/upload/', tinymce_upload, name='tinymce_upload'),
     # See default value in app_settings.JS_SETTINGS.
     # Will be overriden, most probably.
     path('api/settings.json', JSSettings.as_view(), name='js_settings'),

--- a/mapentity/views/__init__.py
+++ b/mapentity/views/__init__.py
@@ -6,6 +6,7 @@ from .base import (
     JSSettings,
     map_screenshot,
     history_delete,
+    tinymce_upload,
 )
 from .generic import (
     Convert,


### PR DESCRIPTION
Demonstration of the feature : 

[mapentity.webm](https://github.com/makinacorpus/django-mapentity/assets/16348048/277c5451-b0a1-4547-87b3-91af74b8feb3)

The local media will be imported into MEDIA_ROOT folder and automatically added to the text area.

Files are store in the media folder and then into the following path : `/tinymce/<generated-uuid>/file.ext`. The generated uuid allow to avoid conflicts if multiple files with the same name are uploaded.

Everything seems to be working fine. 

By default TinyMCE stored a relative path for the uploaded files. I ensure the URL stored for local files are absolute urls therefore  GTR3 and others services can exploit data without having to rebuild URLs and API V2 from Geotrek needs no modification either.

**One important element not done in this PR:** The uploaded files are stored into media but there is no method to delete them if there not used anymore. I'd like some help to find the best strategy to find and remove unused uploaded file. A command that users will need to run ? An asynchrone task ? How can we determine which files are not used ?