### PR TITLE
Feat/improve max characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ CHANGELOG
 - Support sub languages (see https://github.com/GeotrekCE/Geotrek-admin/issues/3801)
 
 
+
 8.6.1      (2023-09-18)
 -----------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----------------------
 
 - Fix of the widget `SelectMultipleWithPop` which did not add the newly created element in the related list (#1299)
+- Add `MAX_CHARACTERS_BY_FIELD` to control the max length of a rich text field. 
+- Deprecate the `MAX_CHARACTERS` parameter
 
 8.6.2      (2024-01-05)
 -----------------------

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -232,9 +232,12 @@ Or change just one parameter (the opacity for example) :
 Edition
 '''''''
 
-For rich text fields, it is possible to a max number of caracters (spaces includes).
-A help message will be added, and color of TinyMCE status bar will be colored in pink.
+For rich text fields, it is possible to indicate a max number of characters on a specified field (spaces includes).
+A help message will be added, and color of TinyMCE status bar and border will be colored in red.
 
 .. code-block :: python
 
-    MAPENTITY_CONFIG['MAX_CHARACTERS'] = 1500
+    MAPENTITY_CONFIG['MAX_CHARACTERS_BY_FIELD'] = { 
+        "tourism_touristicevent": [{'field': 'description_teaser_fr', 'value': 50}, {'field': 'accessibility_fr', 'value': 25}],
+        "trekking_trek": [{'field': 'description_teaser_fr', 'value': 150}],
+    }

--- a/mapentity/forms.py
+++ b/mapentity/forms.py
@@ -106,15 +106,18 @@ class MapEntityForm(TranslatedModelForm):
         self.helper.form_tag = True
 
         # If MAX_CHARACTERS is setted, set help text for rich text fields
-        textfield_help_text = ''
-        max_characters = settings.MAPENTITY_CONFIG.get('MAX_CHARACTERS', None)
-        if max_characters:
-            textfield_help_text = _('%(max)s characters maximum recommended') % {'max': max_characters}
-
+        max_characters_config = settings.MAPENTITY_CONFIG.get('MAX_CHARACTERS', {}) or {}
         # Default widgets
         for fieldname, formfield in self.fields.items():
+            textfield_help_text = ''
             # Custom code because formfield_callback does not work with inherited forms
             if formfield:
+                # set max character limit :
+                if self._meta.model._meta.db_table in max_characters_config:
+                    for conf in max_characters_config[self._meta.model._meta.db_table]:
+                        if fieldname == conf["field"]:
+                            textfield_help_text = _('%(max)s characters maximum recommended') % {'max': conf["value"]}
+
                 # Assign map widget to all geometry fields
                 try:
                     formmodel = self._meta.model

--- a/mapentity/settings.py
+++ b/mapentity/settings.py
@@ -45,6 +45,7 @@ app_settings = dict({
     'MAP_STYLES': _DEFAULT_MAP_STYLES,
     'REGEX_PATH_ATTACHMENTS': r'\.\d+x\d+_q\d+(_crop)?\.(jpg|png|jpeg)$',
     'MAX_CHARACTERS': None,
+    'MAX_CHARACTERS_BY_FIELD': {},
 }, **getattr(settings, 'MAPENTITY_CONFIG', {}))
 
 # default MAP_STYLES should not be replaced but updated by MAPENTITY_CONFIG

--- a/mapentity/static/mapentity/mapentity.helpers.js
+++ b/mapentity/static/mapentity/mapentity.helpers.js
@@ -107,14 +107,27 @@ function tr(s) {
 
 
 function tinyMceInit(editor) {
-    // Overflow on characters count
+    var context = $('body').data();
     editor.on('WordCountUpdate', function(event) {
-        if (("container" in event.target) && (window.SETTINGS.maxCharacters > 0)) {
-            var characters = event.wordCount.characters;
-            if (characters > window.SETTINGS.maxCharacters) {
-                event.target.container.classList.add('cec-overflow');
-            } else {
-                event.target.container.classList.remove('cec-overflow');
+        if (("container" in event.target) && (window.SETTINGS.maxCharacters)) {
+            var fullTableName = context.appname+"_"+context.modelname
+            if (fullTableName in window.SETTINGS.maxCharacters) {
+                var currenInputName = event.target.container.previousSibling.name;
+                window.SETTINGS.maxCharacters[fullTableName].forEach(config => {
+                    if(config.field == currenInputName) {
+                        var statusBar = $(event.target.container).find(".tox-statusbar__wordcount");
+                        $(event.target.container).find(".injectedCount").remove()
+                        $("<p class='injectedCount'>"+event.wordCount.characters+"/"+config.value+" characters</p>").insertBefore(statusBar)
+                        if(event.wordCount.characters > config.value) {
+
+                            event.target.container.classList.add('cec-overflow');
+                            event.target.container.classList.add('is-invalid');
+                        } else {
+                            event.target.container.classList.remove('cec-overflow');
+                            event.target.container.classList.remove('is-invalid');
+                        }
+                    }
+                })
             }
         }
     });

--- a/mapentity/static/mapentity/mapentity.helpers.js
+++ b/mapentity/static/mapentity/mapentity.helpers.js
@@ -109,11 +109,21 @@ function tr(s) {
 function tinyMceInit(editor) {
     var context = $('body').data();
     editor.on('WordCountUpdate', function(event) {
-        if (("container" in event.target) && (window.SETTINGS.maxCharacters)) {
+        console.log(window.SETTINGS);
+        // DEPRECATED paramters maxCharacters -> to remove
+        if (("container" in event.target) && (window.SETTINGS.maxCharacters > 0)) {
+            var characters = event.wordCount.characters;
+            if (characters > window.SETTINGS.maxCharacters) {
+                event.target.container.classList.add('cec-overflow');
+            } else {
+                event.target.container.classList.remove('cec-overflow');
+            }
+        }
+        if (("container" in event.target) && (window.SETTINGS.maxCharactersByField)) {
             var fullTableName = context.appname+"_"+context.modelname
-            if (fullTableName in window.SETTINGS.maxCharacters) {
+            if (fullTableName in window.SETTINGS.maxCharactersByField) {
                 var currenInputName = event.target.container.previousSibling.name;
-                window.SETTINGS.maxCharacters[fullTableName].forEach(config => {
+                window.SETTINGS.maxCharactersByField[fullTableName].forEach(config => {
                     if(config.field == currenInputName) {
                         var statusBar = $(event.target.container).find(".tox-statusbar__wordcount");
                         $(event.target.container).find(".injectedCount").remove()

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -842,6 +842,11 @@ label.requiredField .asteriskField {
 .cec-overflow.tox .tox-statusbar {
     background-color: pink;
 }
+.tox.is-invalid {
+    border-color: #dc3545!important;
+
+}
+
 
 
 /*

--- a/mapentity/views/base.py
+++ b/mapentity/views/base.py
@@ -109,7 +109,9 @@ class JSSettings(JSONResponseMixin, TemplateView):
         # Languages
         dictsettings['languages'] = dict(available=dict(app_settings['TRANSLATED_LANGUAGES']),
                                          default=app_settings['LANGUAGE_CODE'])
+        # MAX_CHARACTERS paramters is deprecated : to remove
         dictsettings['maxCharacters'] = app_settings['MAX_CHARACTERS']
+        dictsettings['maxCharactersByField'] = app_settings['MAX_CHARACTERS_BY_FIELD']
         return dictsettings
 
 

--- a/test_app/tests/test_forms.py
+++ b/test_app/tests/test_forms.py
@@ -36,15 +36,16 @@ class MapEntityFormTest(TestCase):
 
 
 class MapEntityRichTextFormTest(TestCase):
+    old_setting = app_settings.copy()
+    old_setting["MAX_CHARACTERS"] = 10
+    new_setting = app_settings.copy()
+    new_setting['MAX_CHARACTERS_BY_FIELD'] = {
+        "test_app_dummymodel": [{'field': 'short_description', 'value': 5}]
+    }
 
-    def setUp(self):
-        app_settings['MAX_CHARACTERS'] = {
-            "test_app_dummymodel": [{'field': 'short_description', 'value': 5}]
-        }
-
-    @override_settings(MAPENTITY_CONFIG=app_settings)
-    def test_max_characters(self):
-        """Test if help text is set with MAX_CHARACTERS setting"""
+    @override_settings(MAPENTITY_CONFIG=new_setting)
+    def test_max_characters_by_field(self):
+        """Test if help text is set with MAX_CHARACTERS_BY_FIELD setting"""
         sample_object = DummyModel.objects.create()
 
         form = DummyForm(instance=sample_object)
@@ -52,6 +53,14 @@ class MapEntityRichTextFormTest(TestCase):
         self.assertIn('Short description, 5 characters maximum recommended',
                       form.fields['short_description'].help_text)
 
-    def tearDown(self):
-        app_settings['MAX_CHARACTERS'] = 1200
+    @override_settings(MAPENTITY_CONFIG=old_setting)
+    def test_max_characters_global(self):
+        """Test if help text is set with MAX_CHARACTERS setting -> deprecated paramter"""
+        sample_object = DummyModel.objects.create()
 
+        form = DummyForm(instance=sample_object)
+        for field_name in ["description", "short_description"]:
+            self.assertIn(
+                '10 characters maximum recommended',
+                form.fields[field_name].help_text
+            )

--- a/test_app/tests/test_forms.py
+++ b/test_app/tests/test_forms.py
@@ -38,7 +38,9 @@ class MapEntityFormTest(TestCase):
 class MapEntityRichTextFormTest(TestCase):
 
     def setUp(self):
-        app_settings['MAX_CHARACTERS'] = 1200
+        app_settings['MAX_CHARACTERS'] = {
+            "test_app_dummymodel": [{'field': 'short_description', 'value': 5}]
+        }
 
     @override_settings(MAPENTITY_CONFIG=app_settings)
     def test_max_characters(self):
@@ -46,9 +48,10 @@ class MapEntityRichTextFormTest(TestCase):
         sample_object = DummyModel.objects.create()
 
         form = DummyForm(instance=sample_object)
-        self.assertIn('1200 characters maximum recommended', form.fields['description'].help_text)
-        self.assertIn('Short description, 1200 characters maximum recommended',
+        self.assertIn('', form.fields['description'].help_text)
+        self.assertIn('Short description, 5 characters maximum recommended',
                       form.fields['short_description'].help_text)
 
     def tearDown(self):
         app_settings['MAX_CHARACTERS'] = 1200
+


### PR DESCRIPTION
Limite le nombre de caractère uniquement sur les champs spécifiés en configuration.
Le contrôle reste informatif et non bloquant (contrôle effectué côté front)
Voir https://github.com/GeotrekCE/Geotrek-admin/issues/3844
 Le paramètre de configuration a ce format : 
```
MAPENTITY_CONFIG['MAX_CHARACTERS'] = {
    "tourism_touristicevent": [{'field': 'description_teaser_fr', 'value': 5}]
}
```
Je pensais mettre uniquement le nom du modèle en config (`touristicevent` par exemple, mais celui-ci n'est pas forcément unique)
Question : est-ce qu'on maintient une rétrocompatibilité sur l'ancien format de config ?`MAPENTITY_CONFIG['MAX_CHARACTERS'] = <INT>` ? En l'état, si les gens ne change pas leur config, ça fait planter l'app ..
