### PR TITLE
fix add element on SelectMultipleWithProp widget

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.6.1+dev  (XXXX-XX-XX)
 -----------------------
 
+- Fix of the widget `SelectMultipleWithPop` which did not add the newly created element in the related list (#1299)
 
 8.6.1      (2023-09-18)
 -----------------------

--- a/mapentity/static/mapentity/RelatedObjectLookups.js
+++ b/mapentity/static/mapentity/RelatedObjectLookups.js
@@ -87,7 +87,7 @@ function dismissAddRelatedObjectPopup(win, newId, newRepr) {
             }
         }
         // Trigger a change event to update related links if required.
-        django.jQuery(elem).trigger('change');
+        $(elem).trigger("chosen:updated");
     } else {
         var toId = name + "_to";
         o = new Option(newRepr, newId);


### PR DESCRIPTION
L'ajout des éléménts créés à la "volée" via le widget `SelectMultipleWithPop` ne fonctionnait plus. 
Cette PR corrige ce bug