### PR TITLE
Fix new internal user cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ CHANGELOG
 8.8.0+dev  (XXXX-XX-XX)
 -----------------------
 
+**Hotfix**
+
+- Fix new internal user cache 
+
 
 8.8.0      (2024-04-10)
 -----------------------

--- a/mapentity/middleware.py
+++ b/mapentity/middleware.py
@@ -14,21 +14,25 @@ def get_internal_user():
     User = get_user_model()
     cache_key = sha256(app_settings['INTERNAL_USER'].encode()).hexdigest()
 
-    id = 0
+    internal_user = None
 
     if cache_key in cache:
         id = int(cache.get(cache_key))
+        try:
+            internal_user = User.objects.get(pk=id)
+        except User.DoesNotExist:
+            pass
 
-    internal_user, created = User.objects.get_or_create(
-        id=int(id),
-        defaults={
-            'username': app_settings['INTERNAL_USER'],
-            'password': '',
-            'is_active': True
-        }
-    )
-    if created:
-        cache.set(cache_key, internal_user.pk)
+    if not internal_user:
+        internal_user, created = User.objects.get_or_create(
+            username=app_settings['INTERNAL_USER'],
+            defaults={
+                'password': '',
+                'is_active': True
+            }
+        )
+        if created:
+            cache.set(cache_key, internal_user.pk)
     return internal_user
 
 


### PR DESCRIPTION
The `get_internal_user` function was broken:

- on first use when the key for the internal user pk is not in the cache => the get_or_create would not work because there is no user with ID 0 (get fails) and the unique username is already in use (create fails).