### PR TITLE
⚡ [PERF] Delay loading filter form in List Views 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,17 @@ CHANGELOG
 8.10.0+dev (XXXX-XX-XX)
 -----------------------
 
+**Breaking Changes**
+
+- `MapEntityList` view now needs an extra `MapEntityFilter` view to maintain filtering functionalities. If you customize the `FilterSet`, it must be added to: `MapEntityFormatList`, `MapEntityFilter`, and `MapEntityViewSet`. See the "Filters" section in documentation : https://django-mapentity.readthedocs.io/en/stable/customization.html#filters
+
 **UI/UX**
 
 - Move an object's related objects from the properties tab into their own tab
+
+**Performances**
+
+- Delay loading filter options only when opening form
 
 
 8.10.0     (2024-10-02)

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -67,20 +67,36 @@ geographical data. Create a file ``filters.py`` in your app::
     from mapentity.filters import MapEntityFilterSet
 
 
-    class MuseumFilter(MapEntityFilterSet):
+    class MuseumFilterSet(MapEntityFilterSet):
         class Meta:
             model = Museum
             fields = ('name', )
 
 
-Then update ``views.py`` to use your custom filter in your curstom views::
+Then update ``views.py`` to use your custom filter in your custom views::
 
-    from .filters import MuseumFilter
+    from .filters import MuseumFilterSet
+
 
     class MuseumList(MapEntityList):
         model = Museum
-        filterform = MuseumFilter
         columns = ['id', 'name']
+
+
+    class MuseumFilter(MapEntityFilter):
+        model = Museum
+        filterset_class = MuseumFilterSet
+
+
+    class MuseumFormatList(MapEntityFormatList):
+        model = Museum
+        filterset_class = MuseumFilterSet
+
+
+    class MuseumViewSet(MapEntityViewSet):
+        model = Museum
+        filterset_class = MuseumFilterSet
+
 
 
 Forms

--- a/mapentity/locale/en/LC_MESSAGES/django.po
+++ b/mapentity/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-06 14:55+0000\n"
+"POT-Creation-Date: 2025-01-07 10:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,6 +101,9 @@ msgstr ""
 
 msgid "Filter"
 msgstr ""
+
+msgid "Loading"
+msgstr "Chargement"
 
 msgid "Measure distances"
 msgstr ""

--- a/mapentity/locale/fr/LC_MESSAGES/django.po
+++ b/mapentity/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-06 14:55+0000\n"
+"POT-Creation-Date: 2025-01-07 10:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,6 +100,9 @@ msgstr "Aucun(e)"
 
 msgid "Filter"
 msgstr "Filtrer"
+
+msgid "Loading"
+msgstr ""
 
 msgid "Measure distances"
 msgstr "Mesurer les distances"

--- a/mapentity/models.py
+++ b/mapentity/models.py
@@ -27,6 +27,7 @@ ENTITY_LIST = "list"
 ENTITY_VIEWSET = "drf-viewset"
 ENTITY_FORMAT_LIST = "format_list"
 ENTITY_DETAIL = "detail"
+ENTITY_FILTER = "filter"
 ENTITY_MAPIMAGE = "mapimage"
 ENTITY_DOCUMENT = "document"
 ENTITY_MARKUP = "markup"
@@ -37,7 +38,7 @@ ENTITY_DELETE = "delete"
 ENTITY_UPDATE_GEOM = "update_geom"
 
 ENTITY_KINDS = (
-    ENTITY_LIST, ENTITY_VIEWSET, ENTITY_FORMAT_LIST, ENTITY_DETAIL, ENTITY_MAPIMAGE,
+    ENTITY_LIST, ENTITY_FILTER, ENTITY_VIEWSET, ENTITY_FORMAT_LIST, ENTITY_DETAIL, ENTITY_MAPIMAGE,
     ENTITY_DOCUMENT, ENTITY_MARKUP, ENTITY_CREATE, ENTITY_DUPLICATE, ENTITY_UPDATE, ENTITY_DELETE, ENTITY_UPDATE_GEOM
 )
 
@@ -161,6 +162,7 @@ class BaseMapEntityMixin(DuplicateMixin, models.Model):
             ENTITY_DELETE: ENTITY_PERMISSION_DELETE,
             ENTITY_DETAIL: ENTITY_PERMISSION_READ,
             ENTITY_LIST: ENTITY_PERMISSION_READ,
+            ENTITY_FILTER: ENTITY_PERMISSION_READ,
             ENTITY_VIEWSET: ENTITY_PERMISSION_READ,
             ENTITY_MARKUP: ENTITY_PERMISSION_READ,
             ENTITY_FORMAT_LIST: ENTITY_PERMISSION_EXPORT,
@@ -350,6 +352,10 @@ class BaseMapEntityMixin(DuplicateMixin, models.Model):
 
 class MapEntityMixin(BaseMapEntityMixin):
     attachments = GenericRelation(settings.PAPERCLIP_ATTACHMENT_MODEL)
+
+    @classmethod
+    def get_filter_url(cls):
+        return reverse(cls._entity.url_name(ENTITY_FILTER))
 
     class Meta:
         abstract = True

--- a/mapentity/registry.py
+++ b/mapentity/registry.py
@@ -147,6 +147,7 @@ class MapEntityOptions:
     def _url_path(self, view_kind):
         kind_to_urlpath = {
             mapentity_models.ENTITY_LIST: r'^{modelname}/list/$',
+            mapentity_models.ENTITY_FILTER: r'^{modelname}/filter/$',
             mapentity_models.ENTITY_VIEWSET: r'^api/{modelname}/drf/{modelname}$',
             mapentity_models.ENTITY_FORMAT_LIST: r'^{modelname}/list/export/$',
             mapentity_models.ENTITY_DETAIL: r'^{modelname}/(?P<pk>\d+)/$',

--- a/mapentity/static/mapentity/mapentity.map.js
+++ b/mapentity/static/mapentity/mapentity.map.js
@@ -297,6 +297,10 @@ $(window).on('entity:map:list', function (e, data) {
     mapsync.on('reloaded', function (data) {
         t.setsubmit();
     });
+    // On first click on Filter button, load HTML content for form
+    t.$button.click(function (e) {
+         t.load_filter_form(mapsync);
+    });
 
     // Map screenshot button
     var screenshot = new L.Control.Screenshot(window.SETTINGS.urls.screenshot, function () {

--- a/mapentity/templates/mapentity/_mapentity_list_filter.html
+++ b/mapentity/templates/mapentity/_mapentity_list_filter.html
@@ -8,15 +8,11 @@
         <div id="filters-close">
             <a href="#"><i class="bi bi-x-circle-fill"></i></a>
         </div>
-        <form id="mainfilter" action="{{ model.get_datatablelist_url }}">
-            <div class="left form-group">
-                {{ filterform.form.as_p }}
+        <div class="filter-spinner-container text-center">
+            <div class="spinner-border text-primary" role="status">
+                <span class="sr-only">{% trans "Loading" %}</span>
             </div>
-            <div class="right form-group"></div>
-            <div class="actions">
-                <input id="reset" type="reset" class="btn btn-light"/>
-                <a id="filter" class="btn btn-primary"><i class="bi bi-search"></i> {% trans "Filter" %}</a>
-            </div>
-        </form>
+        </div>
+        {% include "mapentity/mapentity_filter.html" %}
     </div>
 </div>

--- a/mapentity/templates/mapentity/mapentity_filter.html
+++ b/mapentity/templates/mapentity/mapentity_filter.html
@@ -1,0 +1,14 @@
+{% load i18n static %}
+
+{% block mainfilter %}
+<form id="mainfilter" action="{{ model.get_datatablelist_url }}" filter-url="{{ filter_url }}">
+    <div class="left form-group">
+        {{ filter.form.as_p }}
+    </div>
+    <div class="right form-group"></div>
+    <div class="actions">
+        <input id="reset" type="reset" class="btn btn-light"/>
+        <a id="filter" class="btn btn-primary"><i class="bi bi-search"></i> {% trans "Filter" %}</a>
+    </div>
+</form>
+{% endblock mainfilter %}

--- a/mapentity/tests/__init__.py
+++ b/mapentity/tests/__init__.py
@@ -336,7 +336,7 @@ class MapEntityTest(TestCase):
             return  # Abstract test should not run
         response = self.client.get(self.model.get_list_url())
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context['filterform'] is not None)
+        self.assertTrue(response.context['filter'] is not None)
 
     # REST API tests
 

--- a/mapentity/views/__init__.py
+++ b/mapentity/views/__init__.py
@@ -10,6 +10,7 @@ from .base import (
 from .generic import (
     Convert,
     MapEntityList,
+    MapEntityFilter,
     MapEntityFormat,
     MapEntityMapImage,
     MapEntityDocument,
@@ -34,6 +35,7 @@ from .mixins import (
 
 MAPENTITY_GENERIC_VIEWS = [
     MapEntityList,
+    MapEntityFilter,
     MapEntityFormat,
     MapEntityMapImage,
     MapEntityDocument,
@@ -48,6 +50,7 @@ MAPENTITY_GENERIC_VIEWS = [
 __all__ = [
     'Convert',
     'MapEntityList',
+    'MapEntityFilter',
     'MapEntityFormat',
     'MapEntityMapImage',
     'MapEntityDocument',

--- a/test_app/filters.py
+++ b/test_app/filters.py
@@ -1,12 +1,18 @@
 from django_filters.rest_framework import BooleanFilter
+from test_app.models import DummyModel, Road
 
 from mapentity.filters import MapEntityFilterSet
-from test_app.models import DummyModel
 
 
-class DummyModelFilter(MapEntityFilterSet):
+class DummyModelFilterSet(MapEntityFilterSet):
     public = BooleanFilter(field_name='public', lookup_expr='exact')
 
     class Meta:
         model = DummyModel
         fields = ('public', 'name')
+
+
+class RoadFilterSet(MapEntityFilterSet):
+    class Meta:
+        model = Road
+        fields = ('id', 'name')

--- a/test_app/templates/test_app/dummymodel_filter.html
+++ b/test_app/templates/test_app/dummymodel_filter.html
@@ -1,0 +1,5 @@
+{% extends "mapentity/mapentity_filter.html" %}
+
+{% block mainfilter %}
+    {{ block.super }}
+{% endblock mainfilter %}

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,5 +1,6 @@
+from test_app.models import City, DummyModel, MushroomSpot, Road
+
 from mapentity.registry import registry
-from test_app.models import DummyModel, MushroomSpot, Road, City
 
 app_name = 'test_app'
 

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -2,20 +2,22 @@ from django.contrib.gis.db.models.functions import Transform
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from mapentity import views as mapentity_views
-from .filters import DummyModelFilter
-from .forms import DummyModelForm, RoadForm, MushroomSpotForm
-from .models import DummyModel, Road, MushroomSpot
-from .serializers import DummySerializer, RoadSerializer, DummyGeojsonSerializer
+
+from .filters import DummyModelFilterSet, RoadFilterSet
+from .forms import DummyModelForm, MushroomSpotForm, RoadForm
+from .models import DummyModel, MushroomSpot, Road
+from .serializers import (DummyGeojsonSerializer, DummySerializer,
+                          RoadSerializer)
 
 
 class DummyList(mapentity_views.MapEntityList):
     model = DummyModel
-    filterform = DummyModelFilter
     searchable_columns = ['id', 'name']
 
 
 class DummyFormat(mapentity_views.MapEntityFormat):
     model = DummyModel
+    filterset_class = DummyModelFilterSet
 
 
 class DummyDocumentOdt(mapentity_views.MapEntityDocumentOdt):
@@ -53,13 +55,18 @@ class DummyViewSet(mapentity_views.MapEntityViewSet):
     serializer_class = DummySerializer
     geojson_serializer_class = DummyGeojsonSerializer
     permission_classes = [DjangoModelPermissionsOrAnonReadOnly]
-    filterset_class = DummyModelFilter
+    filterset_class = DummyModelFilterSet
 
     def get_queryset(self):
         qs = self.model.objects.all()
         if self.format_kwarg == "geojson":
             qs = qs.annotate(api_geom=Transform("geom", 4326))
         return qs
+
+
+class DummyModelFilter(mapentity_views.MapEntityFilter):
+    model = DummyModel
+    filterset_class = DummyModelFilterSet
 
 
 class RoadCreate(mapentity_views.MapEntityCreate):
@@ -72,6 +79,11 @@ class RoadViewSet(mapentity_views.MapEntityViewSet):
     queryset = Road.objects.all()
     serializer_class = RoadSerializer
     permission_classes = [DjangoModelPermissionsOrAnonReadOnly]
+
+
+class RoadList(mapentity_views.MapEntityList):
+    model = Road  # Must be defined to be detected by mapentity
+    filterset_class = RoadFilterSet  # Test that we can also override base filter here
 
 
 class MushroomSpotCreate(mapentity_views.MapEntityCreate):


### PR DESCRIPTION
Optimize List View loading by delaying the loading of filtering options.

When a List View opens, the hidden filter form only includes BBOX to maintain map zoom filtering.

When clicking the "Filter" button, the full FilterSet (including BBOX and all other attributes) loads in the pop-up.

⚠️ **Breaking change**: If you customize the FilterSet, it must be added to: FormatList, Filter, List, and ViewSet