### PR TITLE
💄 [UI/UX] Move an object's related objects from the properties tab into their own tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ CHANGELOG
 8.10.0+dev (XXXX-XX-XX)
 -----------------------
 
+**UI/UX**
+
+- Move an object's related objects from the properties tab into their own tab
+
+
 8.10.0     (2024-10-02)
 -----------------------
 
@@ -72,7 +77,7 @@ CHANGELOG
 
 **Hotfix**
 
-- Fix new internal user cache 
+- Fix new internal user cache
 
 
 8.8.0      (2024-04-10)
@@ -123,7 +128,7 @@ CHANGELOG
 -----------------------
 
 - Fix of the widget `SelectMultipleWithPop` which did not add the newly created element in the related list (#1299)
-- Add `MAX_CHARACTERS_BY_FIELD` to control the max length of a rich text field. 
+- Add `MAX_CHARACTERS_BY_FIELD` to control the max length of a rich text field.
 - Deprecate the `MAX_CHARACTERS` parameter
 
 
@@ -279,7 +284,7 @@ CHANGELOG
 - Add svg extra for easy-thumbnail
 
 
-8.1.2      (2022-06-10)    
+8.1.2      (2022-06-10)
 -----------------------
 
 **Bug fixes**
@@ -301,7 +306,7 @@ CHANGELOG
 - Fix exception recursion in default error 500 view
 
 
-8.1.0      (2022-06-03)                
+8.1.0      (2022-06-03)
 -----------------------
 
 **Improvments**
@@ -317,7 +322,7 @@ CHANGELOG
 - django-geojson is not required anymore
 
 
-8.0.1      (2022-04-13)                
+8.0.1      (2022-04-13)
 -----------------------
 
 **Bug fixes**

--- a/mapentity/locale/en/LC_MESSAGES/django.po
+++ b/mapentity/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 13:37+0000\n"
+"POT-Creation-Date: 2025-01-06 14:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -149,6 +149,9 @@ msgid "DOC"
 msgstr ""
 
 msgid "Properties"
+msgstr ""
+
+msgid "Related objects"
 msgstr ""
 
 msgid "Attached files"

--- a/mapentity/locale/fr/LC_MESSAGES/django.po
+++ b/mapentity/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 13:37+0000\n"
+"POT-Creation-Date: 2025-01-06 14:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -149,6 +149,9 @@ msgstr "DOC"
 
 msgid "Properties"
 msgstr "Propriétés"
+
+msgid "Related objects"
+msgstr "Objets liés"
 
 msgid "Attached files"
 msgstr "Fichiers liés"

--- a/mapentity/templates/mapentity/mapentity_detail.html
+++ b/mapentity/templates/mapentity/mapentity_detail.html
@@ -28,6 +28,16 @@
             {% smart_include "propertiestab" %}
           </a>
         </li>
+
+        {% block related_objects_tab_nav %}
+          <li class="nav-item">
+            <a class="nav-link" id="tab-related-objects" href="#related-objects" data-toggle="tab">
+              <i class="bi-grid"></i>
+              <span class="d-none d-sm-inline">{% trans "Related objects" %}</span>
+            </a>
+          </li>
+        {% endblock related_objects_tab_nav %}
+
         {% block before_attachments_extra_tab_nav %}
         {% endblock %}
         {% block attachments_extra_tab_nav %}
@@ -70,6 +80,13 @@
           {% include template_attributes %}
           {% endblock detailspanel %}
         </div>
+
+        {% block related_objects_tab_content %}
+          <div id="related-objects" class="tab-pane">
+            {% smart_include "detail" %}
+          </div>
+        {% endblock related_objects_tab_content %}
+
         {% block before_attachments_extra_tab_content %}
         {% endblock %}
         <div id="attachments" class="tab-pane">

--- a/mapentity/templates/mapentity/mapentity_detail_attributes.html
+++ b/mapentity/templates/mapentity/mapentity_detail_attributes.html
@@ -1,5 +1,4 @@
 {% load mapentity_tags %}
 
 {% block attributes %}
-    {% smart_include "detail" %}
 {% endblock attributes %}


### PR DESCRIPTION
This restructuring of the detail page aims to reorganize the data into a different set of tabs so further developments can set up a loading system in which the data is only loaded when the user clicks on the associated tab.