### PR TITLE
fix get_expected_datatables_attrs content type in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,6 @@ CHANGELOG
 8.14.5+dev (XXXX-XX-XX)
 -----------------------
 
-**Bug fixes**
-
-- Fix the test issue in get_expected_datatables_attrs
 
 8.14.5     (2025-10-30)
 -----------------------

--- a/test_project/test_app/tests/test_views.py
+++ b/test_project/test_app/tests/test_views.py
@@ -6,6 +6,7 @@ import factory
 from bs4 import BeautifulSoup
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.test import RequestFactory, TestCase
@@ -556,11 +557,13 @@ class LogViewMapentityTest(MapEntityTest):
     get_expected_geojson_attrs = None
 
     def get_expected_datatables_attrs(self):
+        content_type = ContentType.objects.get_for_model(DummyModel)
+
         data = {
             "action_flag": "Addition",
             "action_time": "10/06/2022 12:40:10",
             "change_message": "",
-            "content_type": 12,
+            "content_type": content_type.id,
             "id": 1,
             "object": '<a data-pk="1" href="/dummymodel/1/" >Test_App | Dummy '
             "Model <class 'object'></a>",


### PR DESCRIPTION
# Description

The content type of the tested object is 12 and not 13, then the tests failed.