### PR TITLE
🐛 [Bug fixes] Update popup to allow opening detail page in new tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ CHANGELOG
 **Bug fixes**
 
 - Reduce the size of the help text
+- Enable right click on pop-up 'detail page' button 
+
 
 8.17.1     (2026-02-17)
 -----------------------

--- a/mapentity/templates/mapentity/mapentity_popup_content.html
+++ b/mapentity/templates/mapentity/mapentity_popup_content.html
@@ -5,5 +5,5 @@
             {% for field in attributes %}{{ field|truncatechars:100 }}<br>{% endfor %}
         </p>
     {% endif %}
-    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href='{{ detail_url }}'">{{ button_label }}</button>
+    <a id="detail-btn" href="{{ detail_url }}" class="btn btn-sm btn-info mt-2">{{ button_label }}</a>
 </div>

--- a/test_project/test_app/tests/test_views.py
+++ b/test_project/test_app/tests/test_views.py
@@ -84,7 +84,7 @@ class DummyModelFunctionalTest(MapEntityTest):
             f'        <p class="m-0 p-1">\n'
             f"            a dummy model with a dummy name, a dummy geom, dummy tags, dummy makinins. It is the perfect object…<br>public: no<br>{self.obj.tags.first().label}<br>a dummy model<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/dummymodel/{self.model.objects.first().pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/dummymodel/{self.model.objects.first().pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 


### PR DESCRIPTION
Update detail page button on map to be able to open in new tab